### PR TITLE
Handle ticket type and skip empty wizard pages

### DIFF
--- a/logic/ticket.py
+++ b/logic/ticket.py
@@ -37,6 +37,7 @@ def resolve_proxy_value(field_name: str, proxy_or_value: str) -> str:
 def modal_values_to_fd_ticket(values: dict, ticket_form_id: int | None):
     subject = None
     description = None
+    type_field = None
     custom_fields = {}
 
     for block_id, entry in values.items():
@@ -45,6 +46,8 @@ def modal_values_to_fd_ticket(values: dict, ticket_form_id: int | None):
             subject = val
         elif block_id == "description":
             description = val
+        elif block_id == "type":
+            type_field = val
         else:
             if val is not None and val != "__noop__":
                 if isinstance(val, str) and val.startswith("hash:"):
@@ -64,6 +67,9 @@ def modal_values_to_fd_ticket(values: dict, ticket_form_id: int | None):
             ticket["group_id"] = int(IT_GROUP_ID)
         except ValueError:
             log.warning("⚠️ IT_GROUP_ID not an int; skipping")
+
+    if type_field:
+        ticket["type"] = type_field
 
     if custom_fields:
         ticket["custom_fields"] = custom_fields

--- a/logic/wizard.py
+++ b/logic/wizard.py
@@ -35,6 +35,9 @@ def compute_pages(form: dict, all_fields: list, state_values: dict):
         f = by_id.get(fid)
         if not f or f.get("type") in {"default_subject","default_description"}:
             return
+        ensure_choices(f)
+        if not normalize_blocks(to_slack_block(f)):
+            return
         pages.append(fid)
         selected = selected_value_for(f, state_values)
         if selected is None:

--- a/routes/core.py
+++ b/routes/core.py
@@ -105,7 +105,14 @@ def interactions():
             created = fd_get("/api/v2/admin/ticket_fields")  # dummy ping to keep token warm
             from services.freshdesk import fd_post
             created = fd_post("/api/v2/tickets", fd_ticket)
-            log.info("✅ Ticket created: %s", created.get("id"))
+            ticket_id = created.get("id")
+            log.info("✅ Ticket created: %s", ticket_id)
+            user_id = (payload.get("user") or {}).get("id")
+            if user_id and ticket_id:
+                try:
+                    slack_api("chat.postMessage", {"channel": user_id, "text": f"Ticket created: {ticket_id}"})
+                except Exception as e:
+                    log.exception("Notify user failed: %s", e)
             return jsonify({"response_action": "clear"}), 200
         except Exception as e:
             log.exception("Ticket create failed: %s", e)
@@ -126,7 +133,14 @@ def interactions():
         try:
             from services.freshdesk import fd_post
             created = fd_post("/api/v2/tickets", fd_ticket)
-            log.info("✅ Ticket created: %s", created.get("id"))
+            ticket_id = created.get("id")
+            log.info("✅ Ticket created: %s", ticket_id)
+            user_id = (payload.get("user") or {}).get("id")
+            if user_id and ticket_id:
+                try:
+                    slack_api("chat.postMessage", {"channel": user_id, "text": f"Ticket created: {ticket_id}"})
+                except Exception as e:
+                    log.exception("Notify user failed: %s", e)
             if token and token in WIZARD_SESSIONS:
                 del WIZARD_SESSIONS[token]
             return jsonify({"response_action": "clear"}), 200


### PR DESCRIPTION
## Summary
- include Freshdesk `type` field when mapping modal values to tickets
- skip wizard pages for unsupported fields and notify user after ticket creation

## Testing
- `python -m pytest` *(fails: requests.exceptions.HTTPError: 404 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a7355a3d30833387a1395fba979134