### PR TITLE
fix: map form name to ticket type

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,3 +38,8 @@ PORTAL_FORMS_ORDER = [
     "Customer Notification Form",
     "Security Incident",
 ]
+
+# Map Freshdesk form names to valid ticket type values
+FORM_NAME_TO_TYPE = {
+    "IT Equipment & Facility Support Form": "IT Equipment Support Form",
+}

--- a/logic/ticket.py
+++ b/logic/ticket.py
@@ -1,5 +1,5 @@
 import hashlib, logging
-from config import FRESHDESK_EMAIL, IT_GROUP_ID
+from config import FRESHDESK_EMAIL, IT_GROUP_ID, FORM_NAME_TO_TYPE
 from services.freshdesk import fd_get, get_form_detail
 from logic.mapping import (
     extract_input,
@@ -58,7 +58,8 @@ def modal_values_to_fd_ticket(values: dict, ticket_form_id: int | None):
         try:
             form = get_form_detail(int(ticket_form_id))
             if isinstance(form, dict):
-                type_field = form.get("name")
+                name = form.get("name")
+                type_field = FORM_NAME_TO_TYPE.get(name, name)
         except Exception as e:
             log.warning("Could not derive type from form %s: %s", ticket_form_id, e)
 


### PR DESCRIPTION
## Summary
- map Freshdesk form names to valid ticket type values
- use mapping when deriving ticket type from form

## Testing
- `pytest` *(fails: 404 Client Error: Not Found for url: https://none.freshdesk.com/api/v2/ticket-forms)*

------
https://chatgpt.com/codex/tasks/task_e_68a740449a7c8333a9838017ff72642c