### PR TITLE
Use persistent sessions for API requests

### DIFF
--- a/services/slack.py
+++ b/services/slack.py
@@ -1,14 +1,19 @@
 import requests
 import logging
 from functools import lru_cache
+from requests.adapters import HTTPAdapter
 from config import SLACK_BOT_TOKEN, HTTP_TIMEOUT
 
 log = logging.getLogger(__name__)
 
+_session = requests.Session()
+_session.headers.update({"Authorization": f"Bearer {SLACK_BOT_TOKEN}", "Content-Type": "application/json"})
+_session.mount("https://", HTTPAdapter(pool_connections=20, pool_maxsize=20))
+
+
 def slack_api(method: str, payload: dict):
-    r = requests.post(
+    r = _session.post(
         f"https://slack.com/api/{method}",
-        headers={"Authorization": f"Bearer {SLACK_BOT_TOKEN}", "Content-Type": "application/json"},
         json=payload,
         timeout=HTTP_TIMEOUT
     )


### PR DESCRIPTION
## Summary
- reuse `requests.Session` for Freshdesk and Slack API calls to cut connection setup time

## Testing
- `python -m py_compile services/freshdesk.py services/slack.py`
- `pytest` *(fails: 404 Client Error: Not Found for url: https://none.freshdesk.com/api/v2/ticket-forms)*

------
https://chatgpt.com/codex/tasks/task_e_68a76f2cafac83339c71de2e93ea8f11