### PR TITLE
Refresh Freshdesk field cache on first use and fix wizard flow

### DIFF
--- a/logic/wizard.py
+++ b/logic/wizard.py
@@ -206,7 +206,8 @@ def update_wizard(view_id: str, token: str, view_hash: str | None, new_state_val
         # branches change.
         pages = compute_pages(form, fd_fields, sess["values"])
         # Drop stale answers for fields no longer in the current flow so
-        # that unrelated branches are ignored.
+        # that unrelated branches are ignored. Recompute pages after
+        # trimming to reflect any removed branches.
         by_id = {f.get("id"): f for f in fd_fields}
         valid_names = set()
         for item in pages:
@@ -215,6 +216,7 @@ def update_wizard(view_id: str, token: str, view_hash: str | None, new_state_val
                 if f and f.get("name"):
                     valid_names.add(f["name"])
         sess["values"] = {k: v for k, v in sess["values"].items() if k in valid_names}
+        pages = compute_pages(form, fd_fields, sess["values"])
 
         page = max(0, min(int(sess.get("page", 0)), len(pages) - 1))
         current_item = pages[page]

--- a/services/freshdesk.py
+++ b/services/freshdesk.py
@@ -38,14 +38,16 @@ _FORMS_CACHE: dict[str, object] = {"expires": 0, "data": []}
 _FIELDS_CACHE: dict[str, object] = {"expires": 0, "data": []}
 
 # Attempt to warm the fields cache from the bundled JSON snapshot. If the
-# file exists we keep the data indefinitely and avoid an API call during
-# startup. Missing or malformed files simply fall back to the live API.
+# file exists we load it as a starting point but still refresh from the live
+# API on first use so that updates in Freshdesk are reflected in the question
+# flow. Missing or malformed files simply fall back to the live API.
 _FIELDS_FILE = Path(__file__).resolve().parent.parent / "ticket_fields.json"
 if _FIELDS_FILE.exists():
     try:
         with _FIELDS_FILE.open("r", encoding="utf-8") as fh:
             _FIELDS_CACHE["data"] = json.load(fh)
-            _FIELDS_CACHE["expires"] = float("inf")
+            # expire immediately so fresh data is fetched on first access
+            _FIELDS_CACHE["expires"] = 0
             log.info("Loaded %d ticket fields from %s", len(_FIELDS_CACHE["data"]), _FIELDS_FILE)
     except Exception as e:  # pragma: no cover - best effort only
         log.warning("Failed to load %s: %s", _FIELDS_FILE, e)


### PR DESCRIPTION
## Summary
- ensure Freshdesk ticket field snapshot expires immediately
- recompute wizard pages after removing stale answers to keep question flow relevant

## Testing
- `pytest` *(fails: 404 Client Error: Not Found for url: https://none.freshdesk.com/api/v2/ticket-forms)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5d33139883338255dc4ec7eb63ce