### PR TITLE
Ensure section fields appear in question flow

### DIFF
--- a/logic/single_page.py
+++ b/logic/single_page.py
@@ -16,20 +16,11 @@ def build_fields_for_form(form: dict, all_fields: list, state_values: dict | Non
 
     raw = form_detail.get("fields") or form.get("fields") or []
     id_order = normalize_id_list(raw)
-    id_order = [fid for fid in id_order if not by_id.get(fid, {}).get("section_mappings")]
-
     # children map
     dependent_ids: set[int] = set()
-    for f in all_fields:
-        if f.get("section_mappings"):
-            try:
-                dependent_ids.add(int(f.get("id")))
-            except (TypeError, ValueError):
-                continue
     for fid in id_order:
         for sec in get_sections_cached(fid):
-            for cid in sec.get("fields") or []:
-                dependent_ids.add(cid)
+            dependent_ids.update(normalize_id_list(sec.get("fields") or []))
 
     blocks = []
     subj = next((f for f in all_fields if f.get("type") == "default_subject"), None)

--- a/logic/wizard.py
+++ b/logic/wizard.py
@@ -63,12 +63,7 @@ def compute_pages(form: dict, all_fields: list, state_values: dict):
         for sec in get_sections_cached(fid):
             conditional_children.update(normalize_id_list(sec.get("fields") or []))
     dependent_ids.update(conditional_children)
-    id_order = [
-        fid
-        for fid in id_order
-        if fid not in conditional_children
-        and not by_id.get(fid, {}).get("section_mappings")
-    ]
+    id_order = [fid for fid in id_order if fid not in conditional_children]
 
     # Ignore mandatory fields that aren't dependent on any previous answer.
     # These are often global requirements for customer portals but aren't


### PR DESCRIPTION
## Summary
- Include section-mapped Freshdesk fields when computing wizard and single-page flows
- Simplify dependent field calculation so unconditional section fields are presented

## Testing
- `python -m py_compile logic/wizard.py logic/single_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6d20c728833393315eeac24fbccc