### PR TITLE
feat: parse ticket fields from portal HTML

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ FRESHDESK_API_KEY = os.getenv("FRESHDESK_API_KEY") or ""
 FRESHDESK_EMAIL  = os.getenv("FRESHDESK_EMAIL") or ""
 SLACK_BOT_TOKEN  = os.getenv("SLACK_BOT_TOKEN") or ""
 IT_GROUP_ID      = os.getenv("IT_GROUP_ID", "")
+PORTAL_TICKET_FORM_URL = os.getenv("PORTAL_TICKET_FORM_URL") or f"https://{FRESHDESK_DOMAIN}.freshdesk.com/support/tickets/new"
 
 # Behavior toggles
 ENABLE_WIZARD    = _as_bool(os.getenv("ENABLE_WIZARD"), True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 python-dotenv
+beautifulsoup4

--- a/services/freshdesk.py
+++ b/services/freshdesk.py
@@ -4,8 +4,14 @@ import json
 from pathlib import Path
 import requests
 import logging
+from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
-from config import FRESHDESK_DOMAIN, FRESHDESK_API_KEY, HTTP_TIMEOUT
+from config import (
+    FRESHDESK_DOMAIN,
+    FRESHDESK_API_KEY,
+    HTTP_TIMEOUT,
+    PORTAL_TICKET_FORM_URL,
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +37,62 @@ def fd_post(path: str, payload: dict):
         log.error("❌ FD POST %s -> %s", path, r.text[:800])
     r.raise_for_status()
     return r.json()
+
+
+# --- Portal scraping ------------------------------------------------------
+
+def _scrape_portal_fields() -> list[dict]:
+    """Parse ticket fields from the public Freshdesk portal form.
+
+    This is used as a fallback when the Freshdesk API cannot be queried for
+    ticket field metadata. The parser extracts labels, input names, and any
+    select options from the ``/support/tickets/new`` HTML page. The resulting
+    structure is simplified compared to the API response but sufficient for
+    building a basic question flow.
+    """
+
+    try:
+        resp = requests.get(PORTAL_TICKET_FORM_URL, timeout=HTTP_TIMEOUT)
+        resp.raise_for_status()
+    except Exception as e:
+        log.error("❌ Failed to fetch portal form %s (%s)", PORTAL_TICKET_FORM_URL, e)
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    form = soup.find("form")
+    if not form:
+        return []
+
+    fields: list[dict] = []
+    for label in form.find_all("label"):
+        field_id = label.get("for")
+        if not field_id:
+            continue
+        input_el = form.find(id=field_id)
+        if input_el is None:
+            continue
+
+        name = input_el.get("name") or field_id
+        field_type = input_el.name
+        choices = []
+        if field_type == "select":
+            for opt in input_el.find_all("option"):
+                value = opt.get("value")
+                text = opt.get_text(strip=True)
+                if value is None:
+                    continue
+                choices.append({"value": value, "label": text})
+
+        fields.append(
+            {
+                "id": name,
+                "label": label.get_text(strip=True),
+                "type": field_type,
+                "choices": choices,
+            }
+        )
+
+    return fields
 
 
 # --- Cached helpers ------------------------------------------------------
@@ -64,7 +126,11 @@ def get_ticket_forms_cached(ttl: int = 300):
 def get_ticket_fields_cached(ttl: int = 300):
     now = time.time()
     if now >= _FIELDS_CACHE["expires"]:
-        _FIELDS_CACHE["data"] = fd_get("/api/v2/admin/ticket_fields")
+        try:
+            _FIELDS_CACHE["data"] = fd_get("/api/v2/admin/ticket_fields")
+        except Exception as e:
+            log.warning("Ticket fields API failed (%s); falling back to portal scrape", e)
+            _FIELDS_CACHE["data"] = _scrape_portal_fields()
         _FIELDS_CACHE["expires"] = now + ttl
     return _FIELDS_CACHE["data"]
 


### PR DESCRIPTION
## Summary
- add BeautifulSoup and portal ticket form URL config
- scrape fallback to parse ticket fields directly from portal

## Testing
- `python -m pip install -r requirements.txt`
- `pytest` *(fails: requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://none.freshdesk.com/api/v2/ticket-forms)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7893d80883339ba24c29ac1165f6