### PR TITLE
feat: parse ticket fields from portal HTML

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ FRESHDESK_API_KEY = os.getenv("FRESHDESK_API_KEY") or ""
 FRESHDESK_EMAIL  = os.getenv("FRESHDESK_EMAIL") or ""
 SLACK_BOT_TOKEN  = os.getenv("SLACK_BOT_TOKEN") or ""
 IT_GROUP_ID      = os.getenv("IT_GROUP_ID", "")
+PORTAL_TICKET_FORM_URL = os.getenv("PORTAL_TICKET_FORM_URL") or f"https://{FRESHDESK_DOMAIN}.freshdesk.com/support/tickets/new"
 
 # Behavior toggles
 ENABLE_WIZARD    = _as_bool(os.getenv("ENABLE_WIZARD"), True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 python-dotenv
+beautifulsoup4

--- a/services/freshdesk.py
+++ b/services/freshdesk.py
@@ -4,8 +4,14 @@ import json
 from pathlib import Path
 import requests
 import logging
+from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
-from config import FRESHDESK_DOMAIN, FRESHDESK_API_KEY, HTTP_TIMEOUT
+from config import (
+    FRESHDESK_DOMAIN,
+    FRESHDESK_API_KEY,
+    HTTP_TIMEOUT,
+    PORTAL_TICKET_FORM_URL,
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +37,87 @@ def fd_post(path: str, payload: dict):
         log.error("❌ FD POST %s -> %s", path, r.text[:800])
     r.raise_for_status()
     return r.json()
+
+
+# --- Portal scraping ------------------------------------------------------
+
+def _extract_field_key(raw_name: str | None) -> str | None:
+    """Return the Freshdesk field key from a portal form name.
+
+    Examples::
+
+        "helpdesk_ticket[email]" -> "email"
+        "helpdesk_ticket[custom_field][cf_platform]" -> "cf_platform"
+    """
+    if not raw_name:
+        return None
+    if not raw_name.startswith("helpdesk_ticket["):
+        return raw_name
+    inner = raw_name[len("helpdesk_ticket[") :].rstrip("]")
+    parts = inner.split("][")
+    if parts and parts[0] == "custom_field" and len(parts) > 1:
+        return parts[1]
+    return parts[0] if parts else None
+
+
+def _scrape_portal_fields() -> list[dict]:
+    """Parse ticket fields from the public Freshdesk portal form.
+
+    The portal is treated as the source of truth for field order, labels, and
+    option text. We scrape the rendered form and return a simplified structure
+    that can later be matched against API field metadata.
+    """
+
+    try:
+        resp = requests.get(PORTAL_TICKET_FORM_URL, timeout=HTTP_TIMEOUT)
+        resp.raise_for_status()
+    except Exception as e:
+        log.error("❌ Failed to fetch portal form %s (%s)", PORTAL_TICKET_FORM_URL, e)
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    form = soup.find("form")
+    if not form:
+        return []
+
+    fields: list[dict] = []
+    # Each ``control-group`` represents a single ticket field. Iterating over
+    # these containers preserves the visual order from the portal.
+    for group in form.select(".control-group"):
+        label = group.find("label")
+        input_el = group.find(["input", "select", "textarea"])
+        if not label or input_el is None:
+            continue
+
+        raw_name = input_el.get("name")
+        field_key = _extract_field_key(raw_name)
+        if not field_key:
+            continue
+
+        field_type = input_el.name
+        choices = []
+        if field_type == "select":
+            for opt in input_el.find_all("option"):
+                value = opt.get("value")
+                text = opt.get_text(strip=True)
+                if value is None:
+                    continue
+                choices.append({
+                    "value": value,
+                    "label": text,
+                    "id": opt.get("data-id"),
+                })
+
+        fields.append(
+            {
+                "name": field_key,
+                "label": label.get_text(strip=True),
+                "type": field_type,
+                "choices": choices,
+            }
+        )
+
+    return fields
 
 
 # --- Cached helpers ------------------------------------------------------
@@ -63,8 +150,43 @@ def get_ticket_forms_cached(ttl: int = 300):
 
 def get_ticket_fields_cached(ttl: int = 300):
     now = time.time()
+
+    def _merge(portal_fields: list[dict], api_fields: list[dict]):
+        by_name = {f.get("name"): f for f in api_fields}
+        merged: list[dict] = []
+        for pf in portal_fields:
+            api_f = by_name.get(pf.get("name"))
+            if api_f:
+                # Use API data but keep portal label and option order
+                api_f = api_f.copy()
+                api_f["label"] = pf.get("label") or api_f.get("label")
+                if pf.get("choices") and isinstance(api_f.get("choices"), list):
+                    choices_map = {c.get("value"): c for c in api_f["choices"]}
+                    new_choices = []
+                    for opt in pf["choices"]:
+                        c = choices_map.get(opt.get("value")) or {}
+                        new_choices.append({
+                            "value": c.get("value", opt.get("value")),
+                            "label": opt.get("label", c.get("label")),
+                        })
+                    api_f["choices"] = new_choices
+                merged.append(api_f)
+            else:
+                merged.append(pf)
+        return merged
+
     if now >= _FIELDS_CACHE["expires"]:
-        _FIELDS_CACHE["data"] = fd_get("/api/v2/admin/ticket_fields")
+        portal_fields = _scrape_portal_fields()
+        try:
+            api_fields = fd_get("/api/v2/admin/ticket_fields")
+            _FIELDS_CACHE["data"] = _merge(portal_fields, api_fields) if portal_fields else api_fields
+        except Exception as e:
+            if portal_fields:
+                log.warning("Ticket fields API failed (%s); using portal scrape only", e)
+                _FIELDS_CACHE["data"] = portal_fields
+            else:
+                log.warning("Ticket fields unavailable (%s)", e)
+                _FIELDS_CACHE["data"] = []
         _FIELDS_CACHE["expires"] = now + ttl
     return _FIELDS_CACHE["data"]
 


### PR DESCRIPTION
## Summary
- add BeautifulSoup and portal ticket form URL config
- scrape fallback to parse ticket fields directly from portal
- merge portal order and labels with API metadata for accurate flow

## Testing
- `python -m pip install -r requirements.txt`
- `pytest` *(fails: requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://none.freshdesk.com/api/v2/ticket-forms)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7893d80883339ba24c29ac1165f6