### PR TITLE
Generate question flow from ticket fields

### DIFF
--- a/logic/generate_question_flow.py
+++ b/logic/generate_question_flow.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+TYPE_MAP = {
+    'custom_text': 'text',
+    'default_subject': 'text',
+    'default_description': 'text',
+    'custom_paragraph': 'text',
+    'custom_number': 'number',
+    'custom_decimal': 'number',
+    'custom_date': 'date',
+    'custom_dropdown': 'select',
+    'default_ticket_type': 'select',
+    'default_priority': 'select',
+    'default_status': 'select',
+    'default_source': 'select',
+    'default_group': 'select',
+    'default_agent': 'select',
+    'default_product': 'select',
+    'default_company': 'select',
+    'custom_checkbox': 'checkbox',
+    'nested_field': 'text',
+}
+
+
+def normalize_type(field_type: str) -> str:
+    return TYPE_MAP.get(field_type, 'text')
+
+
+def build_question(field: dict) -> dict:
+    question = {
+        'id': field.get('name'),
+        'question': field.get('label_for_customers') or field.get('label'),
+        'type': normalize_type(field.get('type')),
+        'required': field.get('required_for_customers', False),
+    }
+    choices = field.get('choices')
+    if question['type'] in {'select', 'checkbox'} and choices:
+        if isinstance(choices, dict):
+            question['options'] = list(choices.keys())
+        else:
+            question['options'] = choices
+    return question
+
+
+def main() -> None:
+    ticket_fields_path = Path('ticket_fields.json')
+    question_flow_path = Path('question_flow.json')
+
+    with ticket_fields_path.open() as f:
+        fields = json.load(f)
+
+    questions = [build_question(f) for f in fields]
+
+    with question_flow_path.open('w') as f:
+        json.dump(questions, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/question_flow.json
+++ b/question_flow.json
@@ -1,27 +1,2168 @@
 [
   {
-    "id": "issue_type",
-    "question": "What kind of issue am I dealing with?",
+    "id": "requester",
+    "question": "Requester Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "subject",
+    "question": "Subject",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "ticket_type",
+    "question": "Type",
     "type": "select",
-    "options": ["Hardware", "Software"],
-    "next": {"Hardware": "hardware_serial", "Software": "software_details"}
+    "required": false
   },
   {
-    "id": "hardware_serial",
-    "question": "What's the serial number of the hardware?",
+    "id": "cf_customer_name558285",
+    "question": "Customer Name",
     "type": "text",
-    "next": "final_details"
+    "required": true
   },
   {
-    "id": "software_details",
-    "question": "Which software is acting up?",
-    "type": "text",
-    "next": "final_details"
+    "id": "cf_department",
+    "question": "Employee Department",
+    "type": "select",
+    "required": false
   },
   {
-    "id": "final_details",
-    "question": "Anything else I should know?",
+    "id": "source",
+    "question": "Source",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "status",
+    "question": "Status",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "priority",
+    "question": "Priority",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_assigned_team",
+    "question": "Assigned Team",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "group",
+    "question": "Group",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "agent",
+    "question": "Assigned to",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "product",
+    "question": "Product",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "description",
+    "question": "Description",
     "type": "text",
-    "next": null
+    "required": true
+  },
+  {
+    "id": "cf_facility",
+    "question": "Facility",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "company",
+    "question": "Company",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_severity_14",
+    "question": "Severity",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_data_science_inquiry_type",
+    "question": "How can we help you? ",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_is_this_concerning_fulfilment",
+    "question": "Is this concerning fulfilment?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_related_dashboard_link",
+    "question": "Related Dashboard Link",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_business_impact",
+    "question": "What is the Business Impact of this request? ",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_due_date",
+    "question": "Due Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_body_armor_support_inquiry_type",
+    "question": "How can we help you?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_tracking_number",
+    "question": "Tracking Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_body_armor_root_cause_analysis",
+    "question": "Body Armor Root Cause Analysis",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_body_armor_root_cause",
+    "question": "Body Armor Root Cause",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_implementation_support_inquiry_type",
+    "question": "How can we help you? ",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_shipper_name",
+    "question": "Customer Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_expected_resolution",
+    "question": "What is your expected resolution?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_termination_date",
+    "question": "Termination Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_manager_email",
+    "question": "Manager Email",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_job_title",
+    "question": "Job Title",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_hire_date",
+    "question": "Hire Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_do_not_touch_sla_notification_sent",
+    "question": "(DO NOT TOUCH} SLA Notification Sent",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_environment",
+    "question": "Environment",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_software_platform_request_type",
+    "question": "Software Platform Request Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_root_cause",
+    "question": "Root Cause",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_fulfilled_in_a_stord_facility",
+    "question": "Fulfilled in a Stord Facility?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_please_confirm_this_ticket_is_severity_1_or_2_based_on_criteria",
+    "question": "Please confirm this ticket is Severity 1 or 2 based on Criteria",
+    "type": "checkbox",
+    "required": false
+  },
+  {
+    "id": "cf_name_of_employee",
+    "question": "Name of Employee",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_email_of_employee",
+    "question": "Email of Employee",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_dispute_and_credit_reason",
+    "question": "How can we help you? ",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_facility_request_inquiry_type",
+    "question": "How can we help you? ",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_facility_work_type",
+    "question": "Facility Work Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_it_facility_issues",
+    "question": "IT Facility Issues",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_it_nonfacility_issue_type",
+    "question": "IT Issue (Not facility related)",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_point_of_contact_for_this_issue",
+    "question": "Point of Contact for this Issue?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_anyone_else_youd_like_included_on_this_request",
+    "question": "Anyone else you'd like included on this request?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_anyone_else_youd_like_included_on_this_issue",
+    "question": "Anyone else you'd like included on this issue?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_it_facility_request",
+    "question": "IT Facility Request",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_point_of_contact_for_this_request",
+    "question": "Point of Contact for this Request?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_checkin_date",
+    "question": "Check-In Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_poasn_number",
+    "question": "PO/ASN Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_nci_reason",
+    "question": "NCI Reason",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_nci_reason_description",
+    "question": "NCI Reason Description",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_nci_putaway_location",
+    "question": "NCI Putaway Location",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_business_system_inquiry_type",
+    "question": "Business System Inquiry Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_business_system_category",
+    "question": "Business System Category",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_it_request_not_facility_related",
+    "question": "IT Request (Not facility related)",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_parcel_request_type",
+    "question": "Parcel Request Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_total_units",
+    "question": "Total Units",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_customer_support_inquiry_type",
+    "question": "How can we help? ",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_date_incident_occurred_or_discovered",
+    "question": "Date incident occurred or discovered",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_who_is_impacted",
+    "question": "Who is impacted?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_zendesk_ticket_id",
+    "question": "Zendesk Ticket ID",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_automation_only_opsgenie_alert_trigger",
+    "question": "(AUTOMATION ONLY) OpsGenie Alert Trigger",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_type",
+    "question": "Freshdesk Ticket Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_approximate_location_of_device",
+    "question": "Approximate Location of Device",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_it_facility_ticket_type756918",
+    "question": "IT Facility Ticket Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_system_category",
+    "question": "System Access Category",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_slack_request",
+    "question": "Slack Request",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_packstation_label_type_outbound",
+    "question": "Packstation Label Type (Outbound)",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_equipment_support",
+    "question": "What do you need support with?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_notification_type",
+    "question": "Notification Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_does_a_current_setup_exist_to_accommodate_this_customer",
+    "question": "New Customer Onboarding - Setup Location Options",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_facility561188",
+    "question": "Facility",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_freight_request_type",
+    "question": "Freight Request Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_facility_it_facility_request",
+    "question": "Facility",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_it_application_assistance",
+    "question": "IT Application Assistance",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_additional_setup_notes378229",
+    "question": "Additional Setup Notes",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_it_equipment_type",
+    "question": "IT Equipment Type",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_use_case292040",
+    "question": "Use Case",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_is_the_user_requiring_access_a_new_hire",
+    "question": "Is the user requiring access a new hire?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_user_requiring_access_first_and_last_name",
+    "question": "User Requiring Access (First and Last Name)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_email_of_users_manager521566",
+    "question": "Email of User's Manager",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_level_of_permission_requested",
+    "question": "Level of Permission Requested",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_name_of_user_to_mirror",
+    "question": "Name of User to Mirror",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_hours_gone_unassigned",
+    "question": "Hours Gone Unassigned",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_software_order_request_type",
+    "question": "Software Order Request Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_software_login_issue_request_type",
+    "question": "Software Login Issue Request Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_software_inventory_request_type",
+    "question": "Software Inventory Request Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_software_label_parcel_request_type",
+    "question": "Software Label - Parcel Request Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_software_product_catalog_request_type",
+    "question": "Software Product Catalog Request Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_software_application_request_type",
+    "question": " Software Application Request Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_can_you_access_stordcom",
+    "question": "Can you access stord.com?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_what_is_the_issue",
+    "question": "What is the issue?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_dispute_item_and_reason",
+    "question": "Dispute Item and Reason",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_credit_amount_requested_usd",
+    "question": "Credit Amount Requested (USD)",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_amount_recouped_from_the_vendor_if_applicable",
+    "question": "Amount Recouped from the Vendor (If Applicable)",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_final_approved_amount_usd",
+    "question": "Final Approved Amount (USD)",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_invoice_number",
+    "question": "Invoice Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_are_multiple_devices_impacted",
+    "question": "Are multiple devices impacted?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_what_is_the_url_that_is_being_blocked",
+    "question": "What is the URL that is being blocked?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_user_requiring_access",
+    "question": "User requiring access",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_customer_name",
+    "question": "Customer Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_services_used_by_customer",
+    "question": "Service(s) used by Customer",
+    "type": "checkbox",
+    "required": true
+  },
+  {
+    "id": "cf_new_kit_sku",
+    "question": "New Kit Sku",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_child_sku_description_unit_quantities",
+    "question": "Child Sku, Description, Unit Quantities",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_custom_labeling_details",
+    "question": "Custom Labeling Details",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_packaging_details",
+    "question": "Packaging Details",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_sku",
+    "question": "Sku",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_customer_insert_details",
+    "question": "Customer Insert Details",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_date_needed_by",
+    "question": "Date Needed By",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_release_date",
+    "question": "Release Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_lot_status",
+    "question": "Lot Status",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_lot_number",
+    "question": "Lot Number",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_order_numbers",
+    "question": "Order Number(s)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_classification",
+    "question": "Classification",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_targeted_first_inbound_date",
+    "question": "Targeted First Inbound Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_targeted_first_outbound_date",
+    "question": "Targeted First Outbound Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_how_many_packstations_are_required",
+    "question": "How many packstations are required?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_how_many_handheld_scanners_are_required",
+    "question": "How many Handheld Scanners are required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_how_many_laser_printers_are_required",
+    "question": "How many laser printers are required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_existing_packstations_would_be_used",
+    "question": "What existing packstations would be used?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_additional_configuration_required",
+    "question": "What additional configuration required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_zone_is_the_customer_going_to_be_located_in",
+    "question": "What zone is the customer going to be located in?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_additional_setup_notes",
+    "question": "Additional setup notes",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_load_idpro_number",
+    "question": "Load ID/Pro Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_port_of_entry",
+    "question": "Port of Entry",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_contact_name",
+    "question": "Contact Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_jumpcloud_issue",
+    "question": "JumpCloud Issue",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_users_requiring_access",
+    "question": "User(s) Requiring Access",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_name_of_1password_vault",
+    "question": "Name of 1password Vault",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_targeted_setup_completion_date",
+    "question": "Targeted Setup Completion Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_claim_type",
+    "question": "Claim Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_is_there_another_users_permissions_that_we_should_mirror_for_this_request_if_so_who",
+    "question": "Is there another user\u2019s permissions that we should mirror for this request? If so, who?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_lot_number405269",
+    "question": "Lot Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_approximate_location_of_device_that_needs_troubleshooting",
+    "question": "Approximate location of device that needs troubleshooting",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_approximate_location_of_the_office_printer",
+    "question": "Approximate location of the Office Printer",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_approximate_location_of_printer554535",
+    "question": "Approximate location of Printer",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_what_is_the_exact_website_url_that_is_being_blocked",
+    "question": "What is the exact website URL that is being blocked?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_what_is_your_full_pc_nameoptional",
+    "question": "What is your full PC Name? (optional)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_approximate_location_of_zoom_room",
+    "question": "Approximate location of Zoom Room",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_approximate_location_of_tv",
+    "question": "Approximate location of TV",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_manager_email599832",
+    "question": "Manager Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_use_case",
+    "question": "Use Case",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_laptop_serial_number",
+    "question": "Laptop Serial Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_manager_email42585",
+    "question": "Manager Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_previous_owner",
+    "question": "Previous Owner",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_new_owner",
+    "question": "New Owner",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_carrier",
+    "question": "Carrier",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_tracking_number237470",
+    "question": "Tracking Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_impact_xxxweek",
+    "question": "Impact ($XXX/week)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel3169",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_business_impact258149",
+    "question": "Business Impact",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_expected_resolution228804",
+    "question": "Expected Resolution",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_average_package_weight_lbs",
+    "question": "Average Package Weight (Lbs)",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_average_package_transit_time",
+    "question": "Average Package Transit Time",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_average_package_cost",
+    "question": "Average Package Cost",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_average_package_dimension_l_x_w_x_h",
+    "question": "Average Package Dimension (L x W x H)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_expected_transit_time",
+    "question": "Expected Transit Time",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_origin_zip",
+    "question": "Origin Zip",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_destination_zip",
+    "question": "Destination Zip",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_current_carrier_service_use",
+    "question": "Current Carrier / Service Use",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_current_parcel_rate_card",
+    "question": "Current Parcel Rate Card",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_carrier726400",
+    "question": "Carrier",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_tracking_number38044",
+    "question": "Tracking Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel957067",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_carrier611275",
+    "question": "Carrier",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_tracking_number885062",
+    "question": "Tracking Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel854253",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_1p_or_3p",
+    "question": "1P or 3P?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_hazardous",
+    "question": "Hazardous",
+    "type": "checkbox",
+    "required": false
+  },
+  {
+    "id": "cf_parcel_mrr",
+    "question": "Parcel MRR",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_average_package_weight_lbs919974",
+    "question": "Average Package Weight (Lbs)",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_average_package_dimension_l_x_w_x_h518691",
+    "question": "Average Package Dimension (L x W x H)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_carrier749385",
+    "question": "Carrier",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_tracking_number429356",
+    "question": "Tracking Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_new_shipping_address",
+    "question": "New Shipping Address",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel135238",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_business_impact695375",
+    "question": "Business Impact",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_is_this_an_update_to_an_existing_rule_or_a_new_rule",
+    "question": "Is this an update to an existing rule or a new rule?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel125855",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_parcel_system",
+    "question": "Parcel System",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_system_issue_type",
+    "question": "System Issue Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_business_impact440094",
+    "question": "Business Impact",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_oneoff_or_recurring_issue",
+    "question": "One-off or Recurring Issue",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_shipment_id_s",
+    "question": "Shipment ID (s)",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_order_number_s",
+    "question": "Order Number (s)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_shipper_parcel71553",
+    "question": "Shipper (Parcel)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_business_impact184628",
+    "question": "Business Impact",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_expected_resolution880343",
+    "question": "Expected Resolution",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_business_impact74535",
+    "question": "Business Impact",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_who_needs_to_be_informed",
+    "question": "Who needs to be informed?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_expected_resolution624483",
+    "question": "Expected Resolution",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_operating_system",
+    "question": "Operating System",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_what_programsystem_do_you_need_access_to",
+    "question": "What program/system do you need access to?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_user_requiring_access696083",
+    "question": "User Requiring Access",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_users_manager_email",
+    "question": "User's Manager Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_use_case951518",
+    "question": "Use Case",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_programsystem_do_you_need_access_to282999",
+    "question": "What program/system do you need access to?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_manager_email794951",
+    "question": "Manager Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_is_there_another_users_permissions_that_we_should_mirror_for_this_request",
+    "question": "Is there another user\u2019s permissions that we should mirror for this request? If so, who?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_channel_visibility",
+    "question": "Slack Channel Visibility",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_channel_name",
+    "question": "Slack Channel Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_channel_members",
+    "question": "Slack Channel Members",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_channel_type",
+    "question": "Slack Channel Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_group_name",
+    "question": "Slack Group Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_group_members",
+    "question": "Slack Group Members",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_slack_group_type",
+    "question": "Slack Group Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_google_group_type",
+    "question": "Google Group Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_google_group_mailing_address",
+    "question": "Google Group Mailing Address",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_google_group_name",
+    "question": "Google Group Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_will_external_emails_need_to_be_able_to_send_to_this_group",
+    "question": "Will external emails need to be able to send to this group?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_customer_inventory_subcategories",
+    "question": "How can we help with your inventory? ",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_tracking_number_if_any",
+    "question": "Tracking Number (If any)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_how_can_we_help_with_your_order",
+    "question": "How can we help with your order? ",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_quality_subcategory",
+    "question": "Quality Subcategory",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_platform_subcategory",
+    "question": "Platform Request Type",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_items_number",
+    "question": "Item(s) Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_google_group_members",
+    "question": "Google Group Members (optional for existing group requests)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_invoice_number644266",
+    "question": "Invoice Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_how_can_we_help_with_your_invoice",
+    "question": "How can we help with your invoice? ",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_please_describe_what_is_happening_and_what_should_be_happening",
+    "question": "Please describe what is happening and what should be happening.",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_please_describe_the_issuerequest",
+    "question": "Please describe the issue/request.",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_please_describe_your_issuerequest",
+    "question": "Please Describe your Issue/Request",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_are_they_an_s1w_customer",
+    "question": "Are they an S1W Customer?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_are_they_an_s1c_customer",
+    "question": "Are they an S1C Customer?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_churn_date",
+    "question": "Churn Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_do_they_still_have_inventory_in_1p",
+    "question": "Do they still have inventory in 1P?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_new_or_existing_google_account",
+    "question": "New or Existing Google Account",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_email_address",
+    "question": "Email Address",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_email_of_users_manager",
+    "question": "Email of User's Manager",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_used_for_a_service_account",
+    "question": "Used for a Service Account?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_github_username",
+    "question": "Github Username",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_manager_email436129",
+    "question": "Manager Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_email_address_associated_with_github_account",
+    "question": "Email Address Associated with Github Account",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_teams_do_you_need_access_to",
+    "question": "What Team(s) do you need access to?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_email_of_who_needs_the_license",
+    "question": "Email of who needs the license",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_first_and_last_name_of_user_needing_account",
+    "question": "First and Last Name of User Needing Account",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_is_currently_in_place",
+    "question": "What is currently in place?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_changes_would_you_like_made",
+    "question": "What changes would you like made?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_generate_return_label",
+    "question": "Generate Return Label",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_tracking_numbers",
+    "question": "Tracking Number(s)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_item_description",
+    "question": "Item Description",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_quantity_of_affected_items",
+    "question": "Quantity of Affected Items",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_unit_cost_usd",
+    "question": "Unit Cost (USD)",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_shipping_cost_usd",
+    "question": "Shipping Cost (USD)",
+    "type": "number",
+    "required": false
+  },
+  {
+    "id": "cf_original_delivery_date",
+    "question": "Original Delivery Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_customer_name182205",
+    "question": "Customer Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_packstation_label_type",
+    "question": "Packstation Label Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_how_many_packstations_are_required953535",
+    "question": "How many packstations are required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_how_many_handheld_scanners_are_required250177",
+    "question": "How many Handheld Scanners are required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_how_many_laser_printers_are_required51318",
+    "question": "How many laser printers are required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_additional_configuration_required189561",
+    "question": "What additional configuration required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_zone_is_the_customer_going_to_be_located_in413997",
+    "question": "What zone is the customer going to be located in?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_what_network_setup_needs_to_be_completed",
+    "question": "What network setup needs to be completed?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_additional_setup_notes763134",
+    "question": "Additional setup notes",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_offboarding_churn_date",
+    "question": "Offboarding / Churn Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_facility534784",
+    "question": "Facility",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_s1c_customer",
+    "question": "S1C Customer?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_s1w_customer",
+    "question": "S1W Customer?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_inventory_in_1p",
+    "question": "Inventory in 1P?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_date_of_customer_visit",
+    "question": "Date of Customer Visit",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_it_setup_required",
+    "question": "IT Setup Required?",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_additional_setup_notes598638",
+    "question": "Additional Setup Notes",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_what_zone_is_the_customer_going_to_be_located_in701699",
+    "question": "What zone is the customer going to be located in?",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_name_of_service_account",
+    "question": "Name of Service Account",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_service_account_access_required_user_emails",
+    "question": "Service Account Access Required (User Emails)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_service_account_use_case",
+    "question": "Service Account Use Case",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_number_of_impacted_items",
+    "question": "Number of Impacted Items",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_carrier_name",
+    "question": "Carrier Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_customer_name999740",
+    "question": "Customer Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_date",
+    "question": "Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_google_group_type256235",
+    "question": "Google Group Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_google_group_name607271",
+    "question": "Google Group Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_google_group_mailing_address747096",
+    "question": "Google Group Mailing Address",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_for_a_new_group_will_this_google_group_need_to_receive_external_emails",
+    "question": "For a New Group: Will this Google Group need to receive external emails?",
+    "type": "select",
+    "required": false
+  },
+  {
+    "id": "cf_google_group_members74161",
+    "question": "Google Group Members",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_slack_group_type139252",
+    "question": "Slack Group Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_slack_group_name",
+    "question": "Slack Group Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_slack_group_members",
+    "question": "Slack Group Members",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_slack_channel_name",
+    "question": "Slack Channel Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_slack_channel_type",
+    "question": "Slack Channel Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_slack_channel_visibility",
+    "question": "Slack Channel Visibility",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_slack_channel_members",
+    "question": "Slack Channel Members",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_user_experiencing_issue",
+    "question": "User experiencing issue",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_1password_issue_type",
+    "question": "1Password Issue Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_saas_application_inquiry_type",
+    "question": "SaaS Application Inquiry Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_saas_application_business_impact",
+    "question": "SaaS Application Business Impact",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_saas_application_feature_targeted_completion_date",
+    "question": "SaaS Application Feature Targeted Completion Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_saas_application_assistance_category",
+    "question": "SaaS Application Assistance Category",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_dwell_owner",
+    "question": "Dwell Owner",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_contact_email",
+    "question": "Contact Email",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_contact_phone_number",
+    "question": "Contact Phone Number",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_customer_name91770",
+    "question": "Customer Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_number_of_damaged_units",
+    "question": "Number of Damaged Units",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_value_of_damaged_units",
+    "question": "Value of Damaged Units",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_customer_type",
+    "question": "Customer Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_origin_point",
+    "question": "Origin Point",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_destination_point",
+    "question": "Destination Point",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_pickup_date",
+    "question": "Pick-up Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_product_type",
+    "question": "Product Type",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_weight",
+    "question": "Weight",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_pallet_count",
+    "question": "Pallet Count",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_volume",
+    "question": "Volume",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_expected_start_date",
+    "question": "Expected Start Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_customer_business_name",
+    "question": "Customer Business Name",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_ready_ship_date",
+    "question": "Ready Ship Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_shipper_name888989",
+    "question": "Shipper Name",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_shipper_name_address",
+    "question": "Shipper Name Address",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_city",
+    "question": "Shipper City",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_state",
+    "question": "Shipper State",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_shipper_phone_number",
+    "question": "Shipper Phone Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_shipping_hours",
+    "question": "Shipping Hours",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_name",
+    "question": "Consignee Name",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_address",
+    "question": "Consignee Address",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_city",
+    "question": "Consignee City",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_state",
+    "question": "Consignee State",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_contact_email",
+    "question": "Consignee Contact Email",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_contact_name",
+    "question": "Consignee Contact Name",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_phone_number",
+    "question": "Consignee Phone Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_consignee_hours",
+    "question": "Consignee Hours",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_number_of_piecesdrums_on_pallet",
+    "question": "Number of Pieces/Drums on Pallet",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_special_instructions_for_bol_ie_pu_number_po_if_needed",
+    "question": "Special Instructions for BOL. IE -PU number, PO if needed",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_origin_zip_code",
+    "question": "Origin Zip Code",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_destination_zip_code",
+    "question": "Destination Zip Code",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_dimensions_l_x_w_x_h",
+    "question": "Dimensions (L x W x H) (Inches)",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_weight933256",
+    "question": "Weight",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_commodity",
+    "question": "Commodity",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_nmfc_class",
+    "question": "NMFC# / Class",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_additional_services_needed_lifgate_insurance_etc",
+    "question": "Additional Services Needed (delivery appt, liftgate, residential, etc)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_mode",
+    "question": "Mode",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_container_size",
+    "question": "Container Size",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_is_it_palletized_or_loose_cartons",
+    "question": "Is it palletized or loose cartons? ",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_carton_count",
+    "question": "Carton Count",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_desired_ship_date",
+    "question": "Desired Ship Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_door_to_door_needed_drayage_to_and_from_port",
+    "question": "Door to door needed (drayage to and from port)",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_origin_portairport_preference",
+    "question": "Origin Port/Airport Preference",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_destination_portairport_preference",
+    "question": "Destination Port/Airport Preference ",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_do_you_need_a_customers_broker",
+    "question": "Do you need a customers broker?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_expected_arrival_date",
+    "question": "Expected Arrival Date",
+    "type": "date",
+    "required": true
+  },
+  {
+    "id": "cf_delivery_address",
+    "question": "Delivery Address",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_delivery_window_at_receiver",
+    "question": "Delivery Window at Receiver?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_how_many_free_days_at_port",
+    "question": "How many free days at port?",
+    "type": "number",
+    "required": true
+  },
+  {
+    "id": "cf_target_rate",
+    "question": "Target rate? ",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_billing_address197526",
+    "question": "Billing Address",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_sku828211",
+    "question": "Sku",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_product_name",
+    "question": "Product Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_lot_number909989",
+    "question": "Lot Number",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_expiration_date",
+    "question": "Expiration Date",
+    "type": "date",
+    "required": false
+  },
+  {
+    "id": "cf_received_quantity_if_known",
+    "question": "Received Quantity (if known)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_are_operations_required_to_be_halted",
+    "question": "Are operations required to be halted?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_any_other_relevant_information_manufacturing_date_etc",
+    "question": "Any other relevant information (manufacturing date, etc.)",
+    "type": "text",
+    "required": false
+  },
+  {
+    "id": "cf_has_this_new_hire_completed_all_required_new_hire_paperwork_in_workday",
+    "question": "Has this new hire completed all required new hire paperwork?",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_invoice_number167186",
+    "question": "Invoice Number",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_billing_issue_type",
+    "question": "Billing Issue Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_rate_card_request_type",
+    "question": "Rate Card Request Type",
+    "type": "select",
+    "required": true
+  },
+  {
+    "id": "cf_consumer_first_name",
+    "question": "Consumer First Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_consumer_last_name",
+    "question": "Consumer Last Name",
+    "type": "text",
+    "required": true
+  },
+  {
+    "id": "cf_order_number_associated_with_the_consumer",
+    "question": "Order Number Associated with ",
+    "type": "text",
+    "required": true
   }
 ]


### PR DESCRIPTION
## Summary
- regenerate question_flow.json to include all available ticket fields
- add script to build question_flow.json from ticket_fields.json

## Testing
- `python logic/generate_question_flow.py`
- `python -m py_compile logic/generate_question_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac892af52c83338dc26ac79b58394f