### PR TITLE
Scrape portal section mappings and fallback

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = debug


### PR DESCRIPTION
## Summary
- extend portal field scraper to capture dynamic section mappings and dependent fields
- fall back to scraped section data when the Freshdesk sections API is unavailable
- ensure tests skip debug helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb38a6c8483339b09c53ddd35e457