### PR TITLE
Handle missing form field lists in wizard filter

### DIFF
--- a/tests/test_filter_fields_for_form.py
+++ b/tests/test_filter_fields_for_form.py
@@ -1,0 +1,34 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from logic import wizard
+
+
+def test_filter_fields_for_form_uses_form_detail(monkeypatch):
+    form = {"id": 5}
+    fd_fields = [{"id": 1}, {"id": 2}]
+    monkeypatch.setattr(wizard, "get_form_detail", lambda fid: {"fields": [1]})
+    monkeypatch.setattr(wizard, "get_form_fields_scraped", lambda fid: (_ for _ in ()).throw(Exception("should not call")))
+    monkeypatch.setattr(wizard, "get_sections_cached", lambda fid: [])
+    filtered = wizard.filter_fields_for_form(form, fd_fields)
+    assert [f["id"] for f in filtered] == [1]
+
+
+def test_filter_fields_for_form_scraped_on_failure(monkeypatch):
+    form = {"id": 5}
+    fd_fields = [{"id": 1}, {"id": 2}, {"id": 3}]
+    monkeypatch.setattr(wizard, "get_form_detail", lambda fid: (_ for _ in ()).throw(Exception("boom")))
+    monkeypatch.setattr(wizard, "get_form_fields_scraped", lambda fid: [2])
+    monkeypatch.setattr(wizard, "get_sections_cached", lambda fid: [])
+    filtered = wizard.filter_fields_for_form(form, fd_fields)
+    assert [f["id"] for f in filtered] == [2]
+
+
+def test_filter_fields_for_form_no_ids_returns_all(monkeypatch):
+    form = {"id": 5}
+    fd_fields = [{"id": 1}, {"id": 2}]
+    monkeypatch.setattr(wizard, "get_form_detail", lambda fid: {})
+    monkeypatch.setattr(wizard, "get_form_fields_scraped", lambda fid: [])
+    monkeypatch.setattr(wizard, "get_sections_cached", lambda fid: (_ for _ in ()).throw(Exception("should not call")))
+    filtered = wizard.filter_fields_for_form(form, fd_fields)
+    assert filtered == fd_fields


### PR DESCRIPTION
## Summary
- Load form field IDs via the Freshdesk API when a form lacks its own field list, falling back to scraped data on failure
- Build filter IDs from retrieved list and guard against empty sets to avoid stripping all fields
- Add regression tests for new form field filtering logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc482d320833392e1272966225b01