### PR TITLE
Use Slack profile email for ticket requester

### DIFF
--- a/tests/test_get_user_email.py
+++ b/tests/test_get_user_email.py
@@ -1,0 +1,19 @@
+import types
+from services import slack
+
+
+def test_get_user_email_fallback(monkeypatch):
+    calls = []
+
+    def fake_api(method, payload):
+        calls.append(method)
+        if method == "users.info":
+            return {"ok": True, "user": {"profile": {}}}
+        if method == "users.profile.get":
+            return {"ok": True, "profile": {"email": "u@example.com"}}
+        raise AssertionError("unexpected method")
+
+    monkeypatch.setattr(slack, "slack_api", fake_api)
+    slack.get_user_email.cache_clear()
+    assert slack.get_user_email("U123") == "u@example.com"
+    assert calls == ["users.info", "users.profile.get"]


### PR DESCRIPTION
## Summary
- fallback to Slack `users.profile.get` when `users.info` omits email
- add tests covering the email lookup fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb005d07c8333bd79843d18ed9c06