### PR TITLE
Preserve core field values in wizard

### DIFF
--- a/logic/wizard.py
+++ b/logic/wizard.py
@@ -325,6 +325,8 @@ def update_wizard(view_id: str, token: str, view_hash: str | None, new_state_val
                 f = by_id.get(item)
                 if f and f.get("name"):
                     valid_names.add(f["name"])
+        if "core" in pages:
+            valid_names.update({"subject", "description"})
         sess["values"] = {k: v for k, v in sess["values"].items() if k in valid_names}
         pages = compute_pages(form, fd_fields, sess["values"])
 


### PR DESCRIPTION
## Summary
- Keep subject and description values when pruning wizard session state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adad1a8c148333b074b13645e61bc8